### PR TITLE
User API token management via SAML auth

### DIFF
--- a/cloudsmith_cli/cli/commands/__init__.py
+++ b/cloudsmith_cli/cli/commands/__init__.py
@@ -21,6 +21,7 @@ from . import (
     resync,
     status,
     tags,
+    tokens,
     upstream,
     whoami,
 )

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -86,10 +86,12 @@ def authenticate(ctx, opts, owner, token):
             return
         except exceptions.ApiException as exc:
             if exc.status == 400:
-                click.confirm(
-                    "User already has a token. Would you like to recreate it?",
-                    abort=True,
-                )
+                if "User has already created an API key" in exc.detail:
+                    click.confirm(
+                        "User already has a token. Would you like to recreate it?",
+                        abort=True,
+                    )
+                raise
 
         context_msg = "Failed to refresh the token!"
         with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -4,9 +4,13 @@ import webbrowser
 
 import click
 
+from ...core.api import exceptions, user
+from ...core.api.init import initialise_api
+from ...core.config import create_config_files, new_config_messaging
 from .. import decorators, validators
 from ..exceptions import handle_api_exceptions
 from ..saml import create_configured_session, get_idp_url
+from ..utils import maybe_spinner
 from ..webserver import AuthenticationWebRequestHandler, AuthenticationWebServer
 from .main import main
 
@@ -21,11 +25,18 @@ from .main import main
     prompt=True,
     help="The name of the Cloudsmith organization to authenticate with.",
 )
+@click.option(
+    "-t",
+    "--token",
+    default=False,
+    is_flag=True,
+    help="Retrieve a user API token after successful authentication.",
+)
 @decorators.common_cli_config_options
 @decorators.common_cli_output_options
 @decorators.initialise_api
 @click.pass_context
-def authenticate(ctx, opts, owner):
+def authenticate(ctx, opts, owner, token):
     """Authenticate to Cloudsmith using the org's SAML setup."""
     owner = owner[0].strip("'[]'")
     api_host = opts.api_config.host
@@ -58,3 +69,37 @@ def authenticate(ctx, opts, owner):
             debug=opts.debug,
         )
         auth_server.handle_request()
+
+        if not token:
+            return
+
+        initialise_api()
+        try:
+            api_token = user.create_user_token_saml()
+            click.echo(
+                f"New token value: {click.style(api_token['key'], fg='magenta')}"
+            )
+            create, has_errors = create_config_files(
+                ctx, opts, api_key=api_token["key"]
+            )
+            new_config_messaging(has_errors, opts, create, api_key=api_token["key"])
+            return
+        except exceptions.ApiException as exc:
+            if exc.status == 400:
+                click.confirm(
+                    "User already has a token. Would you like to recreate it?",
+                    abort=True,
+                )
+
+        context_msg = "Failed to refresh the token!"
+        with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+            token_slug = user.list_user_tokens()[0]["slug_perm"]
+
+        click.echo(f"Refreshing token {token_slug}... ", nl=False)
+        with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+            with maybe_spinner(opts):
+                new_token = user.refresh_user_token("token_slug")
+        click.secho("OK", fg="green")
+        click.echo(f"New token value: {click.style(new_token['key'], fg='magenta')}")
+        create, has_errors = create_config_files(ctx, opts, api_key=new_token["key"])
+        new_config_messaging(has_errors, opts, create, api_key=new_token["key"])

--- a/cloudsmith_cli/cli/commands/auth.py
+++ b/cloudsmith_cli/cli/commands/auth.py
@@ -93,7 +93,17 @@ def authenticate(ctx, opts, owner, token):
 
         context_msg = "Failed to refresh the token!"
         with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
-            token_slug = user.list_user_tokens()[0]["slug_perm"]
+            api_tokens = user.list_user_tokens()
+        for t in api_tokens:
+            click.echo("Current tokens:")
+            click.echo(
+                f"Token: {click.style(t['key'], fg='magenta')}, "
+                f"Created: {click.style(t['created'], fg='green')}, "
+                f"slug_perm: {click.style(t['slug_perm'], fg='cyan')}"
+            )
+        token_slug = click.prompt(
+            "Please enter the slug_perm of the token you would like to refresh"
+        )
 
         click.echo(f"Refreshing token {token_slug}... ", nl=False)
         with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):

--- a/cloudsmith_cli/cli/commands/login.py
+++ b/cloudsmith_cli/cli/commands/login.py
@@ -1,20 +1,13 @@
 """CLI/Commands - Get an API token."""
 
-import collections
-import stat
-
 import click
 
 from ...core.api.user import get_user_token
-from ...core.utils import get_help_website
+from ...core.config import create_config_files, new_config_messaging
 from .. import decorators
 from ..exceptions import handle_api_exceptions
 from ..utils import maybe_spinner
 from .main import main
-
-ConfigValues = collections.namedtuple(
-    "ConfigValues", ["reader", "present", "mode", "data"]
-)
 
 
 def validate_login(ctx, param, value):
@@ -24,81 +17,6 @@ def validate_login(ctx, param, value):
     if not value:
         raise click.BadParameter("The value cannot be blank.", param=param)
     return value
-
-
-def create_config_files(ctx, opts, api_key):
-    """Create default config files."""
-    # pylint: disable=unused-argument
-    config_reader = opts.get_config_reader()
-    creds_reader = opts.get_creds_reader()
-    has_config = config_reader.has_default_file()
-    has_creds = creds_reader.has_default_file()
-
-    if has_config and has_creds:
-        create = False
-    else:
-        click.echo()
-        create = click.confirm(
-            "No default config file(s) found, do you want to create them?"
-        )
-
-    click.echo()
-    if not create:
-        click.secho(
-            "For reference here are your default config file locations:", fg="yellow"
-        )
-    else:
-        click.secho(
-            "Great! Let me just create your default configs for you now ...", fg="green"
-        )
-
-    configs = (
-        ConfigValues(reader=config_reader, present=has_config, mode=None, data={}),
-        ConfigValues(
-            reader=creds_reader,
-            present=has_creds,
-            mode=stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP,
-            data={"api_key": api_key},
-        ),
-    )
-
-    has_errors = False
-    for config in configs:
-        click.echo(
-            "%(name)s config file: %(filepath)s ... "
-            % {
-                "name": click.style(config.reader.config_name.capitalize(), bold=True),
-                "filepath": click.style(
-                    config.reader.get_default_filepath(), fg="magenta"
-                ),
-            },
-            nl=False,
-        )
-
-        if not config.present and create:
-            try:
-                ok = config.reader.create_default_file(
-                    data=config.data, mode=config.mode
-                )
-            except OSError as exc:
-                ok = False
-                error_message = exc.strerror
-                has_errors = True
-
-            if ok:
-                click.secho("CREATED", fg="green")
-            else:
-                click.secho("ERROR", fg="red")
-                click.secho(
-                    "The following error occurred while trying to "
-                    "create the file: %(message)s"
-                    % {"message": click.style(error_message, fg="red")}
-                )
-            continue
-
-        click.secho("EXISTS" if config.present else "NOT CREATED", fg="yellow")
-
-    return create, has_errors
 
 
 @main.command(aliases=["token"])
@@ -136,30 +54,4 @@ def login(ctx, opts, login, password):  # pylint: disable=redefined-outer-name
     )
 
     create, has_errors = create_config_files(ctx, opts, api_key=api_key)
-
-    if has_errors:
-        click.echo()
-        click.secho("Oops, please fix the errors and try again!", fg="red")
-        return
-
-    if opts.api_key != api_key:
-        click.echo()
-        if opts.api_key:
-            click.secho(
-                "Note: The above API key doesn't match what you have in "
-                "your default credentials config file.",
-                fg="yellow",
-            )
-        elif not create:
-            click.secho(
-                "Note: Don't forget to put your API key in a config file, "
-                "export it on the environment, or set it via -k.",
-                fg="yellow",
-            )
-            click.secho(
-                "If you need more help please see the documentation: "
-                "%(website)s" % {"website": click.style(get_help_website(), bold=True)}
-            )
-        click.echo()
-
-    click.secho("You're ready to rock, let's start automating!", fg="green")
+    new_config_messaging(has_errors, opts, create, api_key=api_key)

--- a/cloudsmith_cli/cli/commands/tokens.py
+++ b/cloudsmith_cli/cli/commands/tokens.py
@@ -1,0 +1,67 @@
+import click
+
+from ...core.api import user as api
+from .. import command, decorators
+from ..exceptions import handle_api_exceptions
+from ..utils import maybe_print_as_json, maybe_spinner
+from .main import main
+
+
+@main.group(cls=command.AliasGroup, name="tokens")
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@click.pass_context
+def tokens(ctx, opts):
+    """Manage your user API tokens."""
+
+
+@tokens.command(name="list", aliases=["ls"])
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.pass_context
+def list_tokens(ctx, opts):
+    """List all user API tokens."""
+    use_stderr = opts.output in ("json", "pretty_json")
+
+    click.echo("Retrieving API tokens... ", nl=False, err=use_stderr)
+
+    context_msg = "Failed to retrieve API tokens!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            tokens = api.list_user_tokens()
+    click.secho("OK", fg="green", err=use_stderr)
+
+    if maybe_print_as_json(opts, tokens):
+        return
+
+    for token in tokens:
+        click.echo(
+            f"Token: {click.style(token['key'], fg='magenta')}, "
+            f"Created: {click.style(token['created'], fg='green')}, "
+            f"slug_perm: {click.style(token['slug_perm'], fg='cyan')}"
+        )
+
+
+@tokens.command()
+@click.argument("token_slug")
+@decorators.common_cli_config_options
+@decorators.common_cli_output_options
+@decorators.common_api_auth_options
+@decorators.initialise_api
+@click.pass_context
+def refresh(ctx, opts, token_slug):
+    """Refresh a specific API token by its slug."""
+    click.echo(f"Refreshing token {token_slug}... ", nl=False)
+
+    context_msg = "Failed to refresh the token!"
+    with handle_api_exceptions(ctx, opts=opts, context_msg=context_msg):
+        with maybe_spinner(opts):
+            new_token = api.refresh_user_token(token_slug)
+    click.secho("OK", fg="green")
+
+    if maybe_print_as_json(opts, new_token):
+        return
+
+    click.echo(f"New token value: {click.style(new_token['key'], fg='magenta')}")

--- a/cloudsmith_cli/core/api/init.py
+++ b/cloudsmith_cli/core/api/init.py
@@ -12,6 +12,14 @@ from ..rest import RestClient
 from .exceptions import ApiException
 
 
+class BaseApi:
+    def __init__(self, api_client=None):
+        if api_client is None:
+            api_client = cloudsmith_api.ApiClient()
+        self.api_client = api_client
+        self.config = cloudsmith_api.Configuration()
+
+
 def initialise_api(
     debug=False,
     host=None,

--- a/cloudsmith_cli/core/api/user.py
+++ b/cloudsmith_cli/core/api/user.py
@@ -4,7 +4,7 @@ import cloudsmith_api
 
 from .. import ratelimits
 from .exceptions import catch_raise_api_exception
-from .init import get_api_client, unset_api_key
+from .init import BaseApi, get_api_client, unset_api_key
 
 
 def get_user_api():
@@ -37,3 +37,35 @@ def get_user_brief():
 
     ratelimits.maybe_rate_limit(client, headers)
     return data.authenticated, data.slug, data.email, data.name
+
+
+def list_user_tokens() -> list[dict]:
+    """List all user API tokens."""
+    client = get_api_client(BaseApi)
+
+    with catch_raise_api_exception():
+        data, _, headers = client.api_client.call_api(
+            "/user/tokens/",
+            "GET",
+            auth_settings=["apikey", "basic"],
+            response_type="object",
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return data["results"]
+
+
+def refresh_user_token(token_slug: str) -> dict:
+    """Refresh user API token."""
+    client = get_api_client(BaseApi)
+
+    with catch_raise_api_exception():
+        data, _, headers = client.api_client.call_api(
+            f"/user/tokens/{token_slug}/refresh/",
+            "PUT",
+            auth_settings=["apikey", "basic"],
+            response_type="object",
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return data

--- a/cloudsmith_cli/core/api/user.py
+++ b/cloudsmith_cli/core/api/user.py
@@ -28,6 +28,22 @@ def get_user_token(login, password):
     return data.token
 
 
+def create_user_token_saml() -> dict:
+    """Create a new user API token using SAML."""
+    client = get_api_client(BaseApi)
+
+    with catch_raise_api_exception():
+        data, _, headers = client.api_client.call_api(
+            "/user/tokens/",
+            "POST",
+            auth_settings=["apikey"],
+            response_type="object",
+        )
+
+    ratelimits.maybe_rate_limit(client, headers)
+    return data
+
+
 def get_user_brief():
     """Retrieve brief for current user (if any)."""
     client = get_user_api()

--- a/cloudsmith_cli/core/config.py
+++ b/cloudsmith_cli/core/config.py
@@ -1,0 +1,114 @@
+import collections
+import stat
+
+import click
+
+from .utils import get_help_website
+
+ConfigValues = collections.namedtuple(
+    "ConfigValues", ["reader", "present", "mode", "data"]
+)
+
+
+def create_config_files(ctx, opts, api_key):
+    """Create default config files."""
+    # pylint: disable=unused-argument
+    config_reader = opts.get_config_reader()
+    creds_reader = opts.get_creds_reader()
+    has_config = config_reader.has_default_file()
+    has_creds = creds_reader.has_default_file()
+
+    if has_config and has_creds:
+        create = False
+    else:
+        click.echo()
+        create = click.confirm(
+            "No default config file(s) found, do you want to create them?"
+        )
+
+    click.echo()
+    if not create:
+        click.secho(
+            "For reference here are your default config file locations:", fg="yellow"
+        )
+    else:
+        click.secho(
+            "Great! Let me just create your default configs for you now ...", fg="green"
+        )
+
+    configs = (
+        ConfigValues(reader=config_reader, present=has_config, mode=None, data={}),
+        ConfigValues(
+            reader=creds_reader,
+            present=has_creds,
+            mode=stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP,
+            data={"api_key": api_key},
+        ),
+    )
+
+    has_errors = False
+    for config in configs:
+        click.echo(
+            "%(name)s config file: %(filepath)s ... "
+            % {
+                "name": click.style(config.reader.config_name.capitalize(), bold=True),
+                "filepath": click.style(
+                    config.reader.get_default_filepath(), fg="magenta"
+                ),
+            },
+            nl=False,
+        )
+
+        if not config.present and create:
+            try:
+                ok = config.reader.create_default_file(
+                    data=config.data, mode=config.mode
+                )
+            except OSError as exc:
+                ok = False
+                error_message = exc.strerror
+                has_errors = True
+
+            if ok:
+                click.secho("CREATED", fg="green")
+            else:
+                click.secho("ERROR", fg="red")
+                click.secho(
+                    "The following error occurred while trying to "
+                    "create the file: %(message)s"
+                    % {"message": click.style(error_message, fg="red")}
+                )
+            continue
+
+        click.secho("EXISTS" if config.present else "NOT CREATED", fg="yellow")
+
+    return create, has_errors
+
+
+def new_config_messaging(has_errors, opts, create, api_key):
+    if has_errors:
+        click.echo()
+        click.secho("Oops, please fix the errors and try again!", fg="red")
+        return
+
+    if opts.api_key != api_key:
+        click.echo()
+        if opts.api_key:
+            click.secho(
+                "Note: The above API key doesn't match what you have in "
+                "your default credentials config file.",
+                fg="yellow",
+            )
+        elif not create:
+            click.secho(
+                "Note: Don't forget to put your API key in a config file, "
+                "export it on the environment, or set it via -k.",
+                fg="yellow",
+            )
+            click.secho(
+                "If you need more help please see the documentation: "
+                "%(website)s" % {"website": click.style(get_help_website(), bold=True)}
+            )
+        click.echo()
+
+    click.secho("You're ready to rock, let's start automating!", fg="green")

--- a/cloudsmith_cli/core/config.py
+++ b/cloudsmith_cli/core/config.py
@@ -86,6 +86,7 @@ def create_config_files(ctx, opts, api_key):
 
 
 def new_config_messaging(has_errors, opts, create, api_key):
+    """Provide messaging to user after generating new configs"""
     if has_errors:
         click.echo()
         click.secho("Oops, please fix the errors and try again!", fg="red")


### PR DESCRIPTION
This is a "hacky" way of getting around the current inability to create/pull an API token using the CLI when authenticating via SAML